### PR TITLE
Allow ANGULAR_TOKEN_OPTIONS to be used to inject options

### DIFF
--- a/projects/angular-token/src/public_api.ts
+++ b/projects/angular-token/src/public_api.ts
@@ -11,6 +11,8 @@ export {
   AngularTokenOptions
 } from './lib/angular-token.model';
 
+export { ANGULAR_TOKEN_OPTIONS } from './lib/angular-token.token';
+
 export { AngularTokenService } from './lib/angular-token.service';
 
 export { AngularTokenModule } from './lib/angular-token.module';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other... Please describe:

Added `ANGULAR_TOKEN_OPTIONS` as exported by the package to allow allow for angular options to be injected. E.g.:

```
import { AngularTokenModule, ANGULAR_TOKEN_OPTIONS } from 'angular-token';
...
AngularTokenModule.forRoot({
      angularTokenOptionsProvider: {
        provide: ANGULAR_TOKEN_OPTIONS,
        ...
      }
    })
```

## What is the current behavior?

Currently the constant is not exported.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?
[ ] Yes
[x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information