### PR TITLE
Rework: RegisterAccount to send correct data

### DIFF
--- a/projects/angular-token/src/lib/angular-token.service.spec.ts
+++ b/projects/angular-token/src/lib/angular-token.service.spec.ts
@@ -72,16 +72,36 @@ describe('AngularTokenService', () => {
     passwordConfirmation: 'password'
   };
 
+  // Register test data
+  const registerCustomFieldsData: RegisterData = {
+    login: 'test@test.de',
+    first_name: 'John',
+    last_name: 'Doe',
+    password: 'password',
+    passwordConfirmation: 'password'
+  };
+
+  const registerCustomFieldsDataOutput = {
+    email: 'test@test.de',
+    first_name: 'John',
+    last_name: 'Doe',
+    password: 'password',
+    password_confirmation: 'password',
+    confirm_success_url: 	window.location.href
+  };
+
   const registerDataOutput = {
     email: 'test@test.de',
     password: 'password',
-    password_confirmation: 'password'
+    password_confirmation: 'password',
+    confirm_success_url: 	window.location.href
   };
 
   const registerCustomDataOutput = {
     username: 'test@test.de',
     password: 'password',
-    password_confirmation: 'password'
+    password_confirmation: 'password',
+    confirm_success_url: 	window.location.href
   };
 
   // Update password data
@@ -236,16 +256,31 @@ describe('AngularTokenService', () => {
       });
     });
 
-    it('registerAccount should POST data', () => {
+    describe('registerAccount should POST data', () => {
+      it('with standard fields', () => {
 
-      service.registerAccount(registerData).subscribe();
+        service.registerAccount(registerData).subscribe();
 
-      const req = backend.expectOne({
-        url: 'auth',
-        method: 'POST'
+        const req = backend.expectOne({
+          url: 'auth',
+          method: 'POST'
+        });
+
+        expect(req.request.body).toEqual(registerDataOutput);
       });
 
-      expect(req.request.body).toEqual(registerDataOutput);
+      it('with custom fields', () => {
+
+        service.registerAccount(registerCustomFieldsData).subscribe();
+
+        const req = backend.expectOne({
+          url: 'auth',
+          method: 'POST'
+        });
+
+        expect(req.request.body).toEqual(registerCustomFieldsDataOutput);
+      });
+
     });
 
     it('validateToken should GET', () => {

--- a/projects/angular-token/src/lib/angular-token.service.ts
+++ b/projects/angular-token/src/lib/angular-token.service.ts
@@ -135,6 +135,8 @@ export class AngularTokenService implements CanActivate {
   // Register request
   registerAccount(registerData: RegisterData): Observable<any> {
 
+    registerData = Object.assign({}, registerData);
+
     if (registerData.userType == null) {
       this.userType = null;
     } else {
@@ -146,19 +148,17 @@ export class AngularTokenService implements CanActivate {
       registerData.password_confirmation == null &&
       registerData.passwordConfirmation != null
     ) {
-      registerData.password_confirmation  = registerData.passwordConfirmation;
+      registerData.password_confirmation = registerData.passwordConfirmation;
       delete registerData.passwordConfirmation;
     }
 
-    const body = {
-      [this.options.loginField]: registerData.login,
-      password: registerData.password,
-      password_confirmation: registerData.password_confirmation,
-    };
+    const login = registerData.login;
+    delete registerData.login;
+    registerData[this.options.loginField] = login;
 
     registerData.confirm_success_url = this.options.registerAccountCallback;
 
-    return this.http.post(this.getServerPath() + this.options.registerAccountPath, body);
+    return this.http.post(this.getServerPath() + this.options.registerAccountPath, registerData);
   }
 
   // Delete Account


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #462 

## What is the new behavior?
RegisterAccount now sends all params sent by user with `confirm_success_url`

## Does this PR introduce a breaking change?
[ ] Yes
[x] No

## Other information