### PR TITLE
IONIC3 + InAppBrowser Support - no dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4154,8 +4154,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4176,14 +4175,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4198,20 +4195,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4328,8 +4322,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4341,7 +4334,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4356,7 +4348,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4364,14 +4355,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4390,7 +4379,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4471,8 +4459,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4484,7 +4471,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4570,8 +4556,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4607,7 +4592,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4627,7 +4611,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4671,14 +4654,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/projects/angular-token/src/lib/angular-token.model.ts
+++ b/projects/angular-token/src/lib/angular-token.model.ts
@@ -59,6 +59,14 @@ export interface UserType {
   path:           string;
 }
 
+export interface TokenInAppBrowser<T extends {}, Y extends {}> {
+  create(url: string, target?: string, options?: string | Y): T;
+}
+
+export interface TokenPlatform {
+  is(platformName: string): boolean;
+}
+
 export interface AngularTokenOptions {
   angularTokenOptionsProvider?: Provider;
 
@@ -90,4 +98,5 @@ export interface AngularTokenOptions {
   oAuthCallbackPath?:         string;
   oAuthWindowType?:           string;
   oAuthWindowOptions?:        { [key: string]: string; };
+  oAuthBrowserCallbacks?:     { [key: string]: string; };
 }

--- a/projects/angular-token/src/lib/angular-token.service.ts
+++ b/projects/angular-token/src/lib/angular-token.service.ts
@@ -18,7 +18,10 @@ import {
   UserData,
   AuthData,
 
-  AngularTokenOptions
+  AngularTokenOptions,
+
+  TokenPlatform,
+  TokenInAppBrowser,
 } from './angular-token.model';
 
 @Injectable({
@@ -120,6 +123,10 @@ export class AngularTokenService implements CanActivate {
       oAuthCallbackPath:          'oauth_callback',
       oAuthWindowType:            'newWindow',
       oAuthWindowOptions:         null,
+
+      oAuthBrowserCallbacks: {
+        github:                   'auth/github/callback',
+      },
     };
 
     const mergedOptions = (<any>Object).assign(defaultOptions, config);
@@ -215,14 +222,15 @@ export class AngularTokenService implements CanActivate {
     return observ;
   }
 
-  signInOAuth(oAuthType: string) {
+  signInOAuth(oAuthType: string, inAppBrowser?: TokenInAppBrowser<any, any>, platform?: TokenPlatform) {
 
     const oAuthPath: string = this.getOAuthPath(oAuthType);
     const callbackUrl = `${this.global.location.origin}/${this.options.oAuthCallbackPath}`;
     const oAuthWindowType: string = this.options.oAuthWindowType;
     const authUrl: string = this.getOAuthUrl(oAuthPath, callbackUrl, oAuthWindowType);
 
-    if (oAuthWindowType === 'newWindow') {
+    if (oAuthWindowType === 'newWindow' || 
+      (oAuthWindowType == 'inAppBrowser' && (!platform || !platform.is('cordova') || !(platform.is('ios') || platform.is('android'))))) {
       const oAuthWindowOptions = this.options.oAuthWindowOptions;
       let windowOptions = '';
 
@@ -240,6 +248,56 @@ export class AngularTokenService implements CanActivate {
           `closebuttoncaption=Cancel${windowOptions}`
       );
       return this.requestCredentialsViaPostMessage(popup);
+    } else if (oAuthWindowType == 'inAppBrowser') {
+      let oAuthBrowserCallback = this.options.oAuthBrowserCallbacks[oAuthType];
+      if (!oAuthBrowserCallback) {
+        throw new Error(`To login with oAuth provider ${oAuthType} using inAppBrowser the callback (in oAuthBrowserCallbacks) is required.`);
+      }
+      // let oAuthWindowOptions = this.options.oAuthWindowOptions;
+      // let windowOptions = '';
+
+      //  if (oAuthWindowOptions) {
+      //     for (let key in oAuthWindowOptions) {
+      //         windowOptions += `,${key}=${oAuthWindowOptions[key]}`;
+      //     }
+      // }
+
+      let browser = inAppBrowser.create(
+          authUrl,
+          '_blank',
+          'location=no'
+      );
+      
+      return new Observable((observer) => {
+        browser.on('loadstop').subscribe((ev: any) => {
+          if (ev.url.indexOf(oAuthBrowserCallback) > -1) {
+            browser.executeScript({code: "requestCredentials();"}).then((credentials: any) => {
+              this.getAuthDataFromPostMessage(credentials[0]);
+
+              let pollerObserv = interval(400);
+
+              let pollerSubscription = pollerObserv.subscribe(() => {
+                if (this.userSignedIn()) {
+                  observer.next(this.authData);
+                  observer.complete();
+
+                  pollerSubscription.unsubscribe();
+                  browser.close();
+                }
+              }, (error: any) => {
+                observer.error(error);
+                observer.complete();
+             });
+            }, (error: any) => {
+              observer.error(error);
+              observer.complete();
+           });
+          }
+        }, (error: any) => {
+          observer.error(error);
+          observer.complete();
+        });
+      })
     } else if (oAuthWindowType === 'sameWindow') {
       this.global.location.href = authUrl;
     } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
Adds support for IONIC3 InAppBrowser so it can sign in using both user/password or social auth.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Today the app wont'allow to login while running on IONIC, since to open and "listen" to new windows it would have to use InAppBrowser and that's not supported by default.

Issue Number: N/A

## What is the new behavior?
Setting up inAppBrowser as oAuthWindowType, and passing over the social auth callback URLs will allow IONIC Apps running on iOS and Android to sign in with oAuth.

## Does this PR introduce a breaking change?
[ ] Yes
[x] No