### PR TITLE
session-management doc: replace 'email' -> 'login'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 - 🚀 View to demo on [Stackblitz](https://stackblitz.com/github/neroniaky/angular-token)
 - ✨ Learn about it on the [docs site](https://angular-token.gitbook.io/docs)
-- 🔧 Support us by [contributing](https://angular-token.gitbook.io/docs/contribute.md)
+- 🔧 Support us by [contributing](https://angular-token.gitbook.io/docs/contribute)
 
 ---
 

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -11,15 +11,15 @@ Once initialized `AngularTokenService` offers methods for session management:
 - [`.processOAuthCallback()`](#processoauthcallback)
 
 ## .signIn()
-The signIn method is used to sign in the user with email address and password.
+The signIn method is used to sign in the user with login (e.g. email address) and password.
 The optional parameter `type` specifies the name of UserType used for this session.
 
-`signIn({email: string, password: string, userType?: string}): Observable<Response>`
+`signIn({login: string, password: string, userType?: string}): Observable<Response>`
 
 #### Example:
 ```javascript
 this.tokenService.signIn({
-  email:    'example@example.org',
+  login:    'example@example.org',
   password: 'secretPassword'
 }).subscribe(
   res =>      console.log(res),
@@ -43,12 +43,12 @@ this.tokenService.signOut().subscribe(
 ## .registerAccount()
 Sends a new user registration request to the Server.
 
-`registerAccount({email: string, password: string, passwordConfirmation: string, userType?: string}): Observable<Response>`
+`registerAccount({login: string, password: string, passwordConfirmation: string, userType?: string}): Observable<Response>`
 
 #### Example:
 ```javascript
 this.tokenService.registerAccount({
-  email:                'example@example.org',
+  login:                'example@example.org',
   password:             'secretPassword',
   passwordConfirmation: 'secretPassword'
 }).subscribe(


### PR DESCRIPTION
typescript definitions for SignInData, RegisterData etc use key 'login' instead of 'email', so trying to call
tokenService.signIn({email, password})
results in

Argument of type '{ email: string; password: string; }' is not assignable to parameter of type 'SignInData'.
  Object literal may only specify known properties, and 'email' does not exist in type 'SignInData'.ts(2345)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?
[ ] Yes
[ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information