### PR TITLE
Redirect even when authData is present

### DIFF
--- a/projects/angular-token/src/lib/angular-token.service.ts
+++ b/projects/angular-token/src/lib/angular-token.service.ts
@@ -138,32 +138,22 @@ export class AngularTokenService implements CanActivate {
   }
 
   userSignedIn(): boolean {
-    if (this.authData.value == null) {
-      return false;
-    } else {
-      return true;
-    }
+    return !!this.authData.value;
   }
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    if (this.userSignedIn()) {
-      return true;
-    } else {
-      // Store current location in storage (usefull for redirection after signing in)
-      if (this.options.signInStoredUrlStorageKey) {
-        this.localStorage.setItem(
-          this.options.signInStoredUrlStorageKey,
-          state.url
-        );
+  canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    const expiration = this.userSignedIn() && !!this.authData.value.expiry ? (+this.authData.value.expiry * 1000) : 0;
+    const authenticated = Date.now() < expiration;
+
+    if (!authenticated) {
+      if (!!this.options.signInStoredUrlStorageKey) {
+        localStorage.setItem(this.options.signInStoredUrlStorageKey, state.url);
       }
 
-      // Redirect user to sign in if signInRedirect is set
-      if (this.router && this.options.signInRedirect) {
-        this.router.navigate([this.options.signInRedirect]);
-      }
-
-      return false;
+      this.router.navigate([this.options.signInRedirect]);
     }
+
+    return authenticated;
   }
 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently if authData is present, the canActivate guard will not store the redirect route path in localStorage.

Issue Number: [#491](https://github.com/neroniaky/angular-token/issues/491)

## What is the new behavior?
Now, canActivate will attempt to store the redirect route path in local storage based on authData and the value of the expiry key.

## Does this PR introduce a breaking change?
[ ] Yes
[x] No