### PR TITLE
Fix for RegisterData index signature when strictNullChecks is true (#506)

### DIFF
--- a/projects/angular-token/src/lib/angular-token.model.ts
+++ b/projects/angular-token/src/lib/angular-token.model.ts
@@ -16,7 +16,7 @@ export interface RegisterData {
 }
 
 export interface RegisterData {
-  [key: string]: string;
+  [key: string]: string | undefined;
 }
 
 export interface UpdatePasswordData {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
  - Could not find contributing guidelines outlining the commit message requirements. Happy to change as needed.
- [x] Tests for the changes have been added (for bug fixes / features)
  - N/A
- [x] Docs have been added / updated (for bug fixes / features)
  - N/A

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #506 

## What is the new behavior?

`RegisterData` index signature is now `string | undefined` instead of `string` only which supports the `strictNullChecks` compilation flag.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Possible breaking change if users were referencing RegisterData types by index expecting a string only. This change will now produce `string | undefined` so the undefined value will need to be guarded against.

## Other information