### PR TITLE
Save authData in local storage

### DIFF
--- a/projects/angular-token/src/lib/angular-token.service.ts
+++ b/projects/angular-token/src/lib/angular-token.service.ts
@@ -399,8 +399,8 @@ export class AngularTokenService implements CanActivate {
 
   // Reset password request
   resetPassword(resetPasswordData: ResetPasswordData, additionalData?: any): Observable<ApiResponse> {
-    
-    
+
+
     if (additionalData !== undefined) {
       resetPasswordData.additionalData = additionalData;
     }
@@ -556,6 +556,7 @@ export class AngularTokenService implements CanActivate {
 
       if (this.checkAuthData(authData)) {
         this.authData.next(authData);
+        this.setAuthData(authData);
       }
     });
   }


### PR DESCRIPTION
- In order to keep a consisten behaviour across the different ways
of sign in we save the authData in Local Storage when we sign in
using OAuth in the same window just as we do when OAuth with new
window

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, when we sign in using OAuth in the same window the `authData` is not saved in local storage, this cause that the user is signed out each time the page is reloaded.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information